### PR TITLE
Fix git clone failure in configure script.

### DIFF
--- a/scripts/configure-manual.sh
+++ b/scripts/configure-manual.sh
@@ -66,7 +66,7 @@ function download_boost {
 }
 
 function download_git_dependency {
-	git "clone git://github.com/${1}/${2}.git"
+	git clone "git://github.com/${1}/${2}.git"
 	cd "${2}"
 	git checkout "${3}"
 	cd ..


### PR DESCRIPTION
Moved the the open quotation mark to after the clone command for git to prevent the error below.

````
git: 'clone git://github.com/google/googletest.git' is not a git command. See 'git --help'.
````